### PR TITLE
Set binary mode for binary I/O for Windows, where it matters;  KALDI_CYGWIN_COMPAT compile option

### DIFF
--- a/src/bin/add-self-loops.cc
+++ b/src/bin/add-self-loops.cc
@@ -72,7 +72,12 @@ int main(int argc, char *argv[]) {
     if (fst_in_filename == "-") fst_in_filename = "";
     std::string fst_out_filename = po.GetOptArg(3);
     if (fst_out_filename == "-") fst_out_filename = "";
-
+#if _MSC_VER
+    if (fst_in_filename == "")
+      _setmode(_fileno(stdin),  _O_BINARY);
+    if (fst_out_filename == "")
+      _setmode(_fileno(stdout),  _O_BINARY);
+#endif
 
     std::vector<int32> disambig_syms_in;
     if (disambig_in_filename != "") {

--- a/src/bin/make-h-transducer.cc
+++ b/src/bin/make-h-transducer.cc
@@ -82,6 +82,10 @@ int main(int argc, char *argv[]) {
                                                      trans_model,
                                                      hcfg,
                                                      &disambig_syms_out);
+#if _MSC_VER
+    if (fst_out_filename == "")
+      _setmode(_fileno(stdout),  _O_BINARY);
+#endif
 
     if (disambig_out_filename != "") {  // if option specified..
       if (disambig_out_filename == "-")

--- a/src/bin/make-ilabel-transducer.cc
+++ b/src/bin/make-ilabel-transducer.cc
@@ -120,6 +120,11 @@ int main(int argc, char *argv[]) {
     VectorFst<StdArc> map_fst;
     CreateMapFst(old2new_mapping, &map_fst);
 
+#if _MSC_VER
+    if (fst_out_filename == "")
+      _setmode(_fileno(stdout),  _O_BINARY);
+#endif
+
     if (!map_fst.Write(fst_out_filename)) {
       KALDI_ERR << "Error writing output fst to "
                  << (fst_out_filename == "" ? " standard output "

--- a/src/bin/make-pdf-to-tid-transducer.cc
+++ b/src/bin/make-pdf-to-tid-transducer.cc
@@ -23,12 +23,6 @@
 
 
 int main(int argc, char *argv[]) {
-#ifdef _MSC_VER
-  if (0) {
-    fst::VectorFst<fst::StdArc> *fst = NULL;
-    fst->Write("");
-  }
-#endif
   try {
     using namespace kaldi;
     typedef kaldi::int32 int32;
@@ -57,6 +51,11 @@ int main(int argc, char *argv[]) {
     ReadKaldiObject(trans_model_filename, &trans_model);
 
     fst::VectorFst<fst::StdArc> *fst = GetPdfToTransitionIdTransducer(trans_model);
+
+#if _MSC_VER
+    if (fst_out_filename == "")
+      _setmode(_fileno(stdout),  _O_BINARY);
+#endif
 
     if (!fst->Write(fst_out_filename))
       KALDI_ERR << "Error writing fst to "

--- a/src/feat/feature-fbank-test.cc
+++ b/src/feat/feature-fbank-test.cc
@@ -38,7 +38,7 @@ static void UnitTestReadWave() {
   std::cout << "<<<=== Reading waveform\n";
 
   {
-    std::ifstream is("test_data/test.wav");
+    std::ifstream is("test_data/test.wav", std::ios_base::binary);
     WaveData wave;
     wave.Read(is);
     const Matrix<BaseFloat> data(wave.Data());
@@ -112,7 +112,7 @@ static void UnitTestSimple() {
 static void UnitTestHTKCompare1() {
   std::cout << "=== UnitTestHTKCompare1() ===\n";
 
-  std::ifstream is("test_data/test.wav");
+  std::ifstream is("test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -193,7 +193,7 @@ static void UnitTestHTKCompare1() {
 static void UnitTestHTKCompare2() {
   std::cout << "=== UnitTestHTKCompare2() ===\n";
 
-  std::ifstream is("test_data/test.wav");
+  std::ifstream is("test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -273,7 +273,7 @@ static void UnitTestHTKCompare2() {
 static void UnitTestHTKCompare3() {
   std::cout << "=== UnitTestHTKCompare3() ===\n";
 
-  std::ifstream is("test_data/test.wav");
+  std::ifstream is("test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -359,7 +359,7 @@ static void UnitTestHTKCompare3() {
 static void UnitTestHTKCompare4() {
   std::cout << "=== UnitTestHTKCompare4() ===\n";
 
-  std::ifstream is("test_data/test.wav");
+  std::ifstream is("test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);

--- a/src/feat/feature-mfcc-test.cc
+++ b/src/feat/feature-mfcc-test.cc
@@ -38,7 +38,7 @@ static void UnitTestReadWave() {
   std::cout << "<<<=== Reading waveform\n";
 
   {
-    std::ifstream is("test_data/test.wav");
+    std::ifstream is("test_data/test.wav", std::ios_base::binary);
     WaveData wave;
     wave.Read(is);
     const Matrix<BaseFloat> data(wave.Data());
@@ -112,7 +112,7 @@ static void UnitTestSimple() {
 static void UnitTestHTKCompare1() {
   std::cout << "=== UnitTestHTKCompare1() ===\n";
 
-  std::ifstream is("test_data/test.wav");
+  std::ifstream is("test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -196,7 +196,7 @@ static void UnitTestHTKCompare1() {
 static void UnitTestHTKCompare2() {
   std::cout << "=== UnitTestHTKCompare2() ===\n";
 
-  std::ifstream is("test_data/test.wav");
+  std::ifstream is("test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -280,7 +280,7 @@ static void UnitTestHTKCompare2() {
 static void UnitTestHTKCompare3() {
   std::cout << "=== UnitTestHTKCompare3() ===\n";
 
-  std::ifstream is("test_data/test.wav");
+  std::ifstream is("test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -365,7 +365,7 @@ static void UnitTestHTKCompare3() {
 static void UnitTestHTKCompare4() {
   std::cout << "=== UnitTestHTKCompare4() ===\n";
 
-  std::ifstream is("test_data/test.wav");
+  std::ifstream is("test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -448,7 +448,7 @@ static void UnitTestHTKCompare4() {
 static void UnitTestHTKCompare5() {
   std::cout << "=== UnitTestHTKCompare5() ===\n";
 
-  std::ifstream is("test_data/test.wav");
+  std::ifstream is("test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -536,7 +536,7 @@ static void UnitTestHTKCompare6() {
   std::cout << "=== UnitTestHTKCompare6() ===\n";
 
 
-  std::ifstream is("test_data/test.wav");
+  std::ifstream is("test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);

--- a/src/feat/feature-plp-test.cc
+++ b/src/feat/feature-plp-test.cc
@@ -71,7 +71,7 @@ static void UnitTestSimple() {
 static void UnitTestHTKCompare1() {
   std::cout << "=== UnitTestHTKCompare1() ===\n";
 
-  std::ifstream is("test_data/test.wav");
+  std::ifstream is("test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);

--- a/src/feat/feature-sdc-test.cc
+++ b/src/feat/feature-sdc-test.cc
@@ -131,7 +131,7 @@ static void UnitTestEndEffects(Matrix<BaseFloat> &raw_features, int32 window,
 }
 
 int main() {
-  std::ifstream is("test_data/test.wav");
+  std::ifstream is("test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);

--- a/src/feat/online-feature-test.cc
+++ b/src/feat/online-feature-test.cc
@@ -154,7 +154,7 @@ void TestOnlineSpliceFrames() {
 }
 
 void TestOnlineMfcc() {
-  std::ifstream is("../feat/test_data/test.wav");
+  std::ifstream is("../feat/test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -202,7 +202,7 @@ void TestOnlineMfcc() {
 }
 
 void TestOnlinePlp() {
-  std::ifstream is("../feat/test_data/test.wav");
+  std::ifstream is("../feat/test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -250,7 +250,7 @@ void TestOnlinePlp() {
 }
 
 void TestOnlineTransform() {
-  std::ifstream is("../feat/test_data/test.wav");
+  std::ifstream is("../feat/test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -293,7 +293,7 @@ void TestOnlineTransform() {
 }
 
 void TestOnlineAppendFeature() {
-  std::ifstream is("../feat/test_data/test.wav");
+  std::ifstream is("../feat/test_data/test.wav", std::ios_base::binary);
   WaveData wave;
   wave.Read(is);
   KALDI_ASSERT(wave.Data().NumRows() == 1);

--- a/src/feat/pitch-functions-test.cc
+++ b/src/feat/pitch-functions-test.cc
@@ -291,7 +291,7 @@ static void UnitTestKeele() {
       wavefile = "keele/16kHz/"+num+".wav";
     }
     KALDI_LOG << "--- " << wavefile << " ---";
-    std::ifstream is(wavefile.c_str());
+    std::ifstream is(wavefile.c_str(), std::ios_base::binary);
     WaveData wave;
     wave.Read(is);
     KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -323,7 +323,7 @@ static void UnitTestPenaltyFactor() {
         wavefile = "keele/16kHz/"+num+".wav";
       }
       KALDI_LOG << "--- " << wavefile << " ---";
-      std::ifstream is(wavefile.c_str());
+      std::ifstream is(wavefile.c_str(), std::ios_base::binary);
       WaveData wave;
       wave.Read(is);
       KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -356,7 +356,7 @@ static void UnitTestKeeleNccfBallast() {
         wavefile = "keele/16kHz/"+num+".wav";
       }
       KALDI_LOG << "--- " << wavefile << " ---";
-      std::ifstream is(wavefile.c_str());
+      std::ifstream is(wavefile.c_str(), std::ios_base::binary);
       WaveData wave;
       wave.Read(is);
       KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -394,7 +394,7 @@ static void UnitTestPitchExtractionSpeed() {
       wavefile = "keele/16kHz/"+num+".wav";
     }
     KALDI_LOG << "--- " << wavefile << " ---";
-    std::ifstream is(wavefile.c_str());
+    std::ifstream is(wavefile.c_str(), std::ios_base::binary);
     WaveData wave;
     wave.Read(is);
     KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -427,7 +427,7 @@ static void UnitTestPitchExtractorCompareKeele() {
       wavefile = "keele/16kHz/"+num+".wav";
     }
     KALDI_LOG << "--- " << wavefile << " ---";
-    std::ifstream is(wavefile.c_str());
+    std::ifstream is(wavefile.c_str(), std::ios_base::binary);
     WaveData wave;
     wave.Read(is);
     KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -461,7 +461,7 @@ void UnitTestDiffSampleRate() {
       wavefile = "keele/"+samp_rate+"kHz/"+num+".wav";
     }
     KALDI_LOG << "--- " << wavefile << " ---";
-    std::ifstream is(wavefile.c_str());
+    std::ifstream is(wavefile.c_str(), std::ios_base::binary);
     WaveData wave;
     wave.Read(is);
     KALDI_ASSERT(wave.Data().NumRows() == 1);
@@ -485,7 +485,7 @@ void UnitTestProcess() {
       wavefile = "keele/16kHz/"+num+".wav";
     }
     KALDI_LOG << "--- " << wavefile << " ---";
-    std::ifstream is(wavefile.c_str());
+    std::ifstream is(wavefile.c_str(), std::ios_base::binary);
     WaveData wave;
     wave.Read(is);
     KALDI_ASSERT(wave.Data().NumRows() == 1);

--- a/src/util/kaldi-cygwin-io-inl.h
+++ b/src/util/kaldi-cygwin-io-inl.h
@@ -1,0 +1,126 @@
+// util/kaldi-cygwin-io-inl.h
+
+// Copyright 2015 Smart Action Company LLC
+
+// See ../../COPYING for clarification regarding multiple authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//  http://www.apache.org/licenses/LICENSE-2.0
+
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+#ifndef KALDI_UTIL_KALDI_CYGWIN_IO_INL_H_
+#define KALDI_UTIL_KALDI_CYGWIN_IO_INL_H_
+
+#ifndef _MSC_VER
+#error This is a Windows-compatibility file. Something went wery wrong.
+#endif
+
+// This file is included only into kaldi-io.cc, and only if
+// KALDI_CYGWIN_COMPAT is enabled.
+//
+// The routines map unix-ey paths passed to Windows programs from shell
+// scripts in egs. Since shell scripts run under cygwin, they use cygwin's
+// own mount table and a mapping to the file system. It is quite possible to
+// create quite an intricate mapping that only own cygwin API would be able
+// to untangle. Unfortunately, the API to map between filenames is not
+// available to non-cygwin programs. Running cygpath for every file operation
+// would as well be cumbersome. So this is only a simplistic path resolution,
+// assuming that the default cygwin prefix /cygdrive is used, and that all
+// resolved unix-style full paths end up prefixed with /cygdrive. This is
+// quite a sensible approach. We'll also try to map /dev/null and /tmp/**,
+// die on all other /dev/** and warn about all other rooted paths.
+
+namespace kaldi {
+
+static bool prefixp(const std::string& pfx, const std::string& str) {
+  return pfx.length() <= str.length() &&
+    std::equal(pfx.begin(), pfx.end(), str.begin());
+}
+
+static std::string cygprefix("/cygdrive/");
+
+static std::string MapCygwinPathNoTmp(const std::string &filename) {
+  // UNC(?), relative, native Windows and empty paths are ok already.
+  if (prefixp("//", filename) || !prefixp("/", filename))
+    return filename;
+
+  // /dev/...
+  if (filename == "/dev/null")
+    return "\\\\.\\nul";
+  if (prefixp("/dev/", filename)) {
+      KALDI_ERR << "Unable to resolve path '" << filename
+                << "' - only have /dev/null here.";
+      return "\\\\.\\invalid";
+  }
+
+  // /cygdrive/?[/....]
+  int preflen = cygprefix.size();
+  if (prefixp(cygprefix, filename)
+      && filename.size() >= preflen + 1 && isalpha(filename[preflen])
+      && (filename.size() == preflen + 1 || filename[preflen + 1] == '/')) {
+    return std::string() + filename[preflen] + ':' +
+       (filename.size() > preflen + 1 ? filename.substr(preflen + 1) : "/");
+  }
+
+  KALDI_WARN << "Unable to resolve path '" << filename
+             << "' - cannot map unix prefix. "
+             << "Will go on, but breakage will likely ensue.";
+  return filename;
+}
+
+// extern for unit testing.
+std::string MapCygwinPath(const std::string &filename) {
+  // /tmp[/....]
+  if (filename != "/tmp" && !prefixp("/tmp/", filename)) {
+    return MapCygwinPathNoTmp(filename);
+  }
+  char *tmpdir = std::getenv("TMP");
+  if (tmpdir == nullptr)
+    tmpdir = std::getenv("TEMP");
+  if (tmpdir == nullptr) {
+    KALDI_ERR << "Unable to resolve path '" << filename
+              << "' - unable to find temporary directory. Set TMP.";
+    return filename;
+  }
+  // Do not return the result: cygwin environment actually may have unix-style paths.
+  return MapCygwinPathNoTmp(std::string(tmpdir) + filename.substr(4));
+}
+
+// A popen implementation that passes the command line through cygwin
+// bash.exe. This is necessary since some piped commands are cygwin links
+// (e. g. fgrep is a soft link to grep), and some are #!-files, such as
+// gunzip which is a shell script that invokes gzip, or kaldi's own run.pl
+// which is a perl script.
+//
+// _popen uses cmd.exe or whatever shell is specified via the COMSPEC
+// variable. Unfortunately, it adds a hardcoded " /c " to it, so we cannot
+// just substitute the environment variable COMSPEC to point to bash.exe.
+// Instead, quote the command and pass it to bash via its -c switch.
+static FILE *CygwinCompatPopen(const char* command, const char* mode) {
+  // To speed up command launch marginally, optionally accept full path
+  // to bash.exe. This will not work if the path contains spaces, but
+  // no sane person would install cygwin into a space-ridden path.
+  const char* bash_exe = std::getenv("BASH_EXE");
+  std::string qcmd(bash_exe != nullptr ? bash_exe : "bash.exe");
+  qcmd += " -c \"";
+  for (; *command; ++command) {
+    if (*command == '\"')
+      qcmd += '\"';
+    qcmd += *command;
+  }
+  qcmd += '\"';
+
+  return _popen(qcmd.c_str(), mode);
+}
+
+}  // namespace kaldi
+
+#endif  // KALDI_UTIL_KALDI_CYGWIN_IO_INL_H_

--- a/src/util/kaldi-io-test.cc
+++ b/src/util/kaldi-io-test.cc
@@ -294,19 +294,19 @@ void UnitTestIoStandard() {
 
 // This is Windows-specific.
 void UnitTestNativeFilename() {
-#ifdef _MSC_VER
-  extern std::string map_os_path(const std::string &filename);
+#ifdef KALDI_CYGWIN_COMPAT
+  extern std::string MapCygwinPath(const std::string &filename);
 
-  KALDI_ASSERT(map_os_path("") == "");
-  KALDI_ASSERT(map_os_path(".") == ".");
-  KALDI_ASSERT(map_os_path("..") == "..");
-  KALDI_ASSERT(map_os_path("/dev/null")[0] != '/');
-  KALDI_ASSERT(map_os_path("/tmp")[1] == ':');
-  KALDI_ASSERT(map_os_path("/tmp/")[1] == ':');
-  KALDI_ASSERT(map_os_path("/tmp/foo")[1] == ':');
-  KALDI_ASSERT(map_os_path("/cygdrive/c") == "c:/");
-  KALDI_ASSERT(map_os_path("/cygdrive/c/") == "c:/");
-  KALDI_ASSERT(map_os_path("/cygdrive/c/foo") == "c:/foo");
+  KALDI_ASSERT(MapCygwinPath("") == "");
+  KALDI_ASSERT(MapCygwinPath(".") == ".");
+  KALDI_ASSERT(MapCygwinPath("..") == "..");
+  KALDI_ASSERT(MapCygwinPath("/dev/null")[0] != '/');
+  KALDI_ASSERT(MapCygwinPath("/tmp")[1] == ':');
+  KALDI_ASSERT(MapCygwinPath("/tmp/")[1] == ':');
+  KALDI_ASSERT(MapCygwinPath("/tmp/foo")[1] == ':');
+  KALDI_ASSERT(MapCygwinPath("/cygdrive/c") == "c:/");
+  KALDI_ASSERT(MapCygwinPath("/cygdrive/c/") == "c:/");
+  KALDI_ASSERT(MapCygwinPath("/cygdrive/c/foo") == "c:/foo");
 #endif
 }
 

--- a/src/util/kaldi-io-test.cc
+++ b/src/util/kaldi-io-test.cc
@@ -292,15 +292,31 @@ void UnitTestIoStandard() {
   }
 }
 
+// This is Windows-specific.
+void UnitTestNativeFilename() {
+#ifdef _MSC_VER
+  extern std::string map_os_path(const std::string &filename);
 
+  KALDI_ASSERT(map_os_path("") == "");
+  KALDI_ASSERT(map_os_path(".") == ".");
+  KALDI_ASSERT(map_os_path("..") == "..");
+  KALDI_ASSERT(map_os_path("/dev/null")[0] != '/');
+  KALDI_ASSERT(map_os_path("/tmp")[1] == ':');
+  KALDI_ASSERT(map_os_path("/tmp/")[1] == ':');
+  KALDI_ASSERT(map_os_path("/tmp/foo")[1] == ':');
+  KALDI_ASSERT(map_os_path("/cygdrive/c") == "c:/");
+  KALDI_ASSERT(map_os_path("/cygdrive/c/") == "c:/");
+  KALDI_ASSERT(map_os_path("/cygdrive/c/foo") == "c:/foo");
+#endif
+}
 
 }  // end namespace kaldi.
-
 
 
 int main() {
   using namespace kaldi;
 
+  UnitTestNativeFilename();
   UnitTestIoNew(false);
   UnitTestIoNew(true);
   UnitTestIoPipe(true);

--- a/src/util/kaldi-io.cc
+++ b/src/util/kaldi-io.cc
@@ -20,6 +20,7 @@
 #include "base/kaldi-math.h"
 #include "util/text-utils.h"
 #include "util/parse-options.h"
+#include <cstdlib>
 #include <errno.h>
 
 #include "util/kaldi-pipebuf.h"
@@ -133,6 +134,106 @@ InputType ClassifyRxfilename(const std::string &filename) {
   }
 }
 
+#ifdef _MSC_VER
+  // A popen implementation that passes the command line through cygwin
+  // bash.exe. This is necessary since some piped commands are cygwin links
+  // (e. g. fgrep is a soft link to grep), and some are #!-files, such as
+  // gunzip which is a shell script that invokes gzip, or kaldi's own run.pl
+  // which is a perl script.
+  //
+  // _popen uses cmd.exe or whatever shell is specified via the COMSPEC
+  // variable. Unfortunately, it adds a hardcoded " /c " to it, so we cannot
+  // just substitute the environment variable COMSPEC to point to bash.exe.
+  // Instead, quote the command and pass it to bash via its -c switch.
+  FILE *popen(const char* command, const char* mode) {
+    // To speed up command launch marginally, optionally accept full path
+    // to bash.exe. This will not work if the path contains spaces, but
+    // no sane person would install cygwin into a space-ridden path.
+    const char* bash_exe = std::getenv("BASH_EXE");
+    std::string qcmd(bash_exe != nullptr ? bash_exe : "bash.exe");
+    qcmd += " -c \"";
+    for (; *command; ++command) {
+      if (*command == '\"')
+        qcmd += '\"';
+      qcmd += *command;
+    }
+    qcmd += '\"';
+
+    return _popen(qcmd.c_str(), mode);
+  }
+#endif  // _MSC_VER
+
+#ifdef _MSC_VER
+// Massage filename into an OS native format. This is chiefly for Windows.
+// Since shell scripts run under cygwin, they use cygwin's own mount table
+// and a mapping to the file system. It is quite possible to create quite an
+// intricate mapping that only own cygwin API would be able to untangle.
+// Unfortunately, the API to map between filenames is not available to non-
+// cygwin programs. Running cygpath for every file operation would as well
+// be cumbersome. So this is only a simplistic path resolution, assuming that
+// the default cygwin prefix /cygdrive is used, and that all resolved
+// unix-style full paths end up prefixed with /cygdrive. This is quite a
+// sensible approach. We'll also try to map /dev/null and /tmp/**, die on all
+// other /dev/** and warn about all other rooted paths.
+static bool prefixp(const std::string& pfx, const std::string& str) {
+  return pfx.length() <= str.length() &&
+    std::equal(pfx.begin(), pfx.end(), str.begin());
+}
+
+static std::string cygprefix("/cygdrive/");  // Ease the use of a -D later.
+
+static std::string map_os_path_no_tmp(const std::string &filename) {
+  // UNC(?), relative, native Windows and empty paths are ok already.
+  if (prefixp("//", filename) || !prefixp("/", filename))
+    return filename;
+
+  // /dev/...
+  if (filename == "/dev/null")
+    return "\\\\.\\nul";
+  if (prefixp("/dev/", filename)) {
+      KALDI_ERR << "Unable to resolve path '" << filename
+                << "' - only have /dev/null here.";
+      return "\\\\.\\invalid";
+  }
+
+  // /cygdrive/?[/....]
+  // 0----5---90 1
+  int preflen = cygprefix.size();
+  if (prefixp(cygprefix, filename)
+      && filename.size() >= preflen + 1 && isalpha(filename[preflen])
+      && (filename.size() == preflen + 1 || filename[preflen + 1] == '/')) {
+    return std::string() + filename[preflen] + ':' +
+       (filename.size() > preflen + 1 ? filename.substr(preflen + 1) : "/");
+  }
+
+  KALDI_WARN << "Unable to resolve path '" << filename
+             << "' - cannot map unix prefix. "
+             << "Will go on, but breakage will likely ensue.";
+  return filename;
+}
+
+// extern for unit testing.
+std::string map_os_path(const std::string &filename) {
+  // /tmp[/....]
+  if (filename != "/tmp" && !prefixp("/tmp/", filename)) {
+    return map_os_path_no_tmp(filename);
+  }
+  char *tmpdir = std::getenv("TMP");
+  if (tmpdir == nullptr)
+    tmpdir = std::getenv("TEMP");
+  if (tmpdir == nullptr) {
+    KALDI_ERR << "Unable to resolve path '" << filename
+              << "' - unable to find temporary directory. Set TMP.";
+    return filename;
+  }
+  // Do not return the result: cygwin environment actually may have unix-style paths.
+  return map_os_path_no_tmp(std::string(tmpdir) + filename.substr(4));
+}
+
+#else  // _MSC_VER
+// Identity on unix-ey file systems.
+#define map_os_path(x) x
+#endif  // _MSC_VER
 
 class OutputImplBase {
  public:
@@ -151,8 +252,9 @@ class FileOutputImpl: public OutputImplBase {
     if (os_.is_open()) KALDI_ERR << "FileOutputImpl::Open(), "
                                 << "open called on already open file.";
     filename_ = filename;
-    os_.open(filename_.c_str(), binary ? std::ios_base::out|std::ios_base::binary
-             : std::ios_base::out);
+    os_.open(map_os_path(filename_).c_str(),
+             binary ? std::ios_base::out | std::ios_base::binary
+                    : std::ios_base::out);
     return os_.is_open();
   }
 
@@ -228,7 +330,7 @@ class PipeOutputImpl: public OutputImplBase {
     KALDI_ASSERT(wxfilename.length() != 0 && wxfilename[0] == '|');  // should start with '|'
     std::string cmd_name(wxfilename, 1);
 #ifdef _MSC_VER
-    f_ = _popen(cmd_name.c_str(), (binary ? "wb" : "w"));
+    f_ = popen(cmd_name.c_str(), (binary ? "wb" : "w"));
 #else
     f_ = popen(cmd_name.c_str(), "w");
 #endif
@@ -322,8 +424,9 @@ class FileInputImpl: public InputImplBase {
   virtual bool Open(const std::string &filename, bool binary) {
     if (is_.is_open()) KALDI_ERR << "FileInputImpl::Open(), "
                                 << "open called on already open file.";
-    is_.open(filename.c_str(), binary ? std::ios_base::in|std::ios_base::binary
-             : std::ios_base::in);
+    is_.open(map_os_path(filename).c_str(),
+             binary ? std::ios_base::in | std::ios_base::binary
+                    : std::ios_base::in);
     return is_.is_open();
   }
 
@@ -383,7 +486,6 @@ class StandardInputImpl: public InputImplBase {
   bool is_open_;
 };
 
-
 class PipeInputImpl: public InputImplBase {
  public:
   PipeInputImpl(): f_ (NULL), is_(NULL) { }
@@ -395,7 +497,7 @@ class PipeInputImpl: public InputImplBase {
            rxfilename[rxfilename.length()-1] == '|');  // should end with '|'
     std::string cmd_name(rxfilename, 0, rxfilename.length()-1);
 #ifdef _MSC_VER
-    f_ = _popen(cmd_name.c_str(), (binary ? "rb" : "r"));
+    f_ = popen(cmd_name.c_str(), (binary ? "rb" : "r"));
 #else
     f_ = popen(cmd_name.c_str(), "r");
 #endif
@@ -542,8 +644,9 @@ class OffsetFileInputImpl: public InputImplBase {
       } else {
         is_.close();  // don't bother checking error status of is_.
         filename_ = tmp_filename;
-        is_.open(filename_.c_str(), binary ? std::ios_base::in|std::ios_base::binary
-                 : std::ios_base::in);
+        is_.open(map_os_path(filename_).c_str(),
+                 binary ? std::ios_base::in | std::ios_base::binary
+                        : std::ios_base::in);
         if (!is_.is_open()) return false;
         else return Seek(offset);
       }
@@ -551,8 +654,9 @@ class OffsetFileInputImpl: public InputImplBase {
       size_t offset;
       SplitFilename(rxfilename, &filename_, &offset);
       binary_ = binary;
-      is_.open(filename_.c_str(), binary ? std::ios_base::in|std::ios_base::binary
-               : std::ios_base::in);
+      is_.open(map_os_path(filename_).c_str(),
+                binary ? std::ios_base::in | std::ios_base::binary
+                      : std::ios_base::in);
       if (!is_.is_open()) return false;
       else return Seek(offset);
     }

--- a/src/util/kaldi-io.cc
+++ b/src/util/kaldi-io.cc
@@ -24,6 +24,24 @@
 #include <errno.h>
 
 #include "util/kaldi-pipebuf.h"
+
+#ifdef KALDI_CYGWIN_COMPAT
+#include "util/kaldi-cygwin-io-inl.h"
+#define MapOsPath(x) MapCygwinPath(x)
+#else  // KALDI_CYGWIN_COMPAT
+#define MapOsPath(x) x
+#endif  // KALDI_CYGWIN_COMPAT
+
+#ifdef _MSC_VER
+static FILE *popen(const char* command, const char* mode) {
+#ifdef KALDI_CYGWIN_COMPAT
+  return kaldi::CygwinCompatPopen(command, mode);
+#else  // KALDI_CYGWIN_COMPAT
+  return _popen(command, mode);
+#endif  // KALDI_CYGWIN_COMPAT
+}
+#endif  // _MSC_VER
+
 namespace kaldi {
 
 #ifndef _MSC_VER // on VS, we don't need this type.
@@ -134,107 +152,6 @@ InputType ClassifyRxfilename(const std::string &filename) {
   }
 }
 
-#ifdef _MSC_VER
-  // A popen implementation that passes the command line through cygwin
-  // bash.exe. This is necessary since some piped commands are cygwin links
-  // (e. g. fgrep is a soft link to grep), and some are #!-files, such as
-  // gunzip which is a shell script that invokes gzip, or kaldi's own run.pl
-  // which is a perl script.
-  //
-  // _popen uses cmd.exe or whatever shell is specified via the COMSPEC
-  // variable. Unfortunately, it adds a hardcoded " /c " to it, so we cannot
-  // just substitute the environment variable COMSPEC to point to bash.exe.
-  // Instead, quote the command and pass it to bash via its -c switch.
-  FILE *popen(const char* command, const char* mode) {
-    // To speed up command launch marginally, optionally accept full path
-    // to bash.exe. This will not work if the path contains spaces, but
-    // no sane person would install cygwin into a space-ridden path.
-    const char* bash_exe = std::getenv("BASH_EXE");
-    std::string qcmd(bash_exe != nullptr ? bash_exe : "bash.exe");
-    qcmd += " -c \"";
-    for (; *command; ++command) {
-      if (*command == '\"')
-        qcmd += '\"';
-      qcmd += *command;
-    }
-    qcmd += '\"';
-
-    return _popen(qcmd.c_str(), mode);
-  }
-#endif  // _MSC_VER
-
-#ifdef _MSC_VER
-// Massage filename into an OS native format. This is chiefly for Windows.
-// Since shell scripts run under cygwin, they use cygwin's own mount table
-// and a mapping to the file system. It is quite possible to create quite an
-// intricate mapping that only own cygwin API would be able to untangle.
-// Unfortunately, the API to map between filenames is not available to non-
-// cygwin programs. Running cygpath for every file operation would as well
-// be cumbersome. So this is only a simplistic path resolution, assuming that
-// the default cygwin prefix /cygdrive is used, and that all resolved
-// unix-style full paths end up prefixed with /cygdrive. This is quite a
-// sensible approach. We'll also try to map /dev/null and /tmp/**, die on all
-// other /dev/** and warn about all other rooted paths.
-static bool prefixp(const std::string& pfx, const std::string& str) {
-  return pfx.length() <= str.length() &&
-    std::equal(pfx.begin(), pfx.end(), str.begin());
-}
-
-static std::string cygprefix("/cygdrive/");  // Ease the use of a -D later.
-
-static std::string map_os_path_no_tmp(const std::string &filename) {
-  // UNC(?), relative, native Windows and empty paths are ok already.
-  if (prefixp("//", filename) || !prefixp("/", filename))
-    return filename;
-
-  // /dev/...
-  if (filename == "/dev/null")
-    return "\\\\.\\nul";
-  if (prefixp("/dev/", filename)) {
-      KALDI_ERR << "Unable to resolve path '" << filename
-                << "' - only have /dev/null here.";
-      return "\\\\.\\invalid";
-  }
-
-  // /cygdrive/?[/....]
-  // 0----5---90 1
-  int preflen = cygprefix.size();
-  if (prefixp(cygprefix, filename)
-      && filename.size() >= preflen + 1 && isalpha(filename[preflen])
-      && (filename.size() == preflen + 1 || filename[preflen + 1] == '/')) {
-    return std::string() + filename[preflen] + ':' +
-       (filename.size() > preflen + 1 ? filename.substr(preflen + 1) : "/");
-  }
-
-  KALDI_WARN << "Unable to resolve path '" << filename
-             << "' - cannot map unix prefix. "
-             << "Will go on, but breakage will likely ensue.";
-  return filename;
-}
-
-// extern for unit testing.
-std::string map_os_path(const std::string &filename) {
-  // /tmp[/....]
-  if (filename != "/tmp" && !prefixp("/tmp/", filename)) {
-    return map_os_path_no_tmp(filename);
-  }
-  char *tmpdir = std::getenv("TMP");
-  if (tmpdir == nullptr)
-    tmpdir = std::getenv("TEMP");
-  if (tmpdir == nullptr) {
-    KALDI_ERR << "Unable to resolve path '" << filename
-              << "' - unable to find temporary directory. Set TMP.";
-    return filename;
-  }
-  // Do not return the result: cygwin environment actually may have unix-style paths.
-  return map_os_path_no_tmp(std::string(tmpdir) + filename.substr(4));
-}
-
-#else  // _MSC_VER
-// Identity on unix-ey file systems.
-#define map_os_path(x) x
-#endif  // _MSC_VER
-
 class OutputImplBase {
  public:
   // Open will open it as a file (no header), and return true
@@ -252,7 +169,7 @@ class FileOutputImpl: public OutputImplBase {
     if (os_.is_open()) KALDI_ERR << "FileOutputImpl::Open(), "
                                 << "open called on already open file.";
     filename_ = filename;
-    os_.open(map_os_path(filename_).c_str(),
+    os_.open(MapOsPath(filename_).c_str(),
              binary ? std::ios_base::out | std::ios_base::binary
                     : std::ios_base::out);
     return os_.is_open();
@@ -424,7 +341,7 @@ class FileInputImpl: public InputImplBase {
   virtual bool Open(const std::string &filename, bool binary) {
     if (is_.is_open()) KALDI_ERR << "FileInputImpl::Open(), "
                                 << "open called on already open file.";
-    is_.open(map_os_path(filename).c_str(),
+    is_.open(MapOsPath(filename).c_str(),
              binary ? std::ios_base::in | std::ios_base::binary
                     : std::ios_base::in);
     return is_.is_open();
@@ -496,11 +413,7 @@ class PipeInputImpl: public InputImplBase {
     KALDI_ASSERT(rxfilename.length() != 0 &&
            rxfilename[rxfilename.length()-1] == '|');  // should end with '|'
     std::string cmd_name(rxfilename, 0, rxfilename.length()-1);
-#ifdef _MSC_VER
     f_ = popen(cmd_name.c_str(), (binary ? "rb" : "r"));
-#else
-    f_ = popen(cmd_name.c_str(), "r");
-#endif
 
     if (!f_) {  // Failure.
       KALDI_WARN << "Failed opening pipe for reading, command is: "
@@ -644,7 +557,7 @@ class OffsetFileInputImpl: public InputImplBase {
       } else {
         is_.close();  // don't bother checking error status of is_.
         filename_ = tmp_filename;
-        is_.open(map_os_path(filename_).c_str(),
+        is_.open(MapOsPath(filename_).c_str(),
                  binary ? std::ios_base::in | std::ios_base::binary
                         : std::ios_base::in);
         if (!is_.is_open()) return false;
@@ -654,7 +567,7 @@ class OffsetFileInputImpl: public InputImplBase {
       size_t offset;
       SplitFilename(rxfilename, &filename_, &offset);
       binary_ = binary;
-      is_.open(map_os_path(filename_).c_str(),
+      is_.open(MapOsPath(filename_).c_str(),
                 binary ? std::ios_base::in | std::ios_base::binary
                       : std::ios_base::in);
       if (!is_.is_open()) return false;


### PR DESCRIPTION
Set binary mode for binary I/O for Windows, where it matters. …

KALDI_CYGWIN_COMPAT compile option:
- Pipe all commands through cygwin bash shell, so proper commands are invoked.
- Handle minimum subset of cygwin-formatted unix paths on Windows.

Parent track:
   d79a8c9 P
   4638962 C
   3b67707 C
   bd8e180 C
   7d46558 C
   f27d74e C
